### PR TITLE
fix: enforce consistent hero animation sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,6 +340,11 @@
                 if (window.initRotatingText) {
                     window.initRotatingText();
                 }
+
+                // Recompute animation delays now that headline/bullets may have changed
+                if (window.applyDynamicDelays) {
+                    window.applyDynamicDelays();
+                }
             })
             .catch(err => {
                 console.error('Failed to load variants:', err);

--- a/styles.css
+++ b/styles.css
@@ -585,7 +585,9 @@ body {
 }
 
 .fade-in-stats .stat-progress-bar::after {
-    animation: progressSweep 7s linear 5.2s infinite;
+    /* Start after stats are visible; JS sets --progress-delay dynamically */
+    animation: progressSweep 7s linear infinite;
+    animation-delay: var(--progress-delay, 5.2s);
 }
 
 .stat-progress-bar.paused::after {


### PR DESCRIPTION
This PR standardizes the hero animation order across variants and dynamic content.\n\nChanges\n- Compute dynamic animation delays so the sequence is consistent: brand → headline (per word) → body → bullets → form.\n- Recompute delays after variant copy loads, so word count changes don’t break timing.\n- Make stat progress sweep delay configurable via CSS var and set from JS.\n- Stagger stat columns in JS to avoid nth-child fragility.\n- Start StatCycler after the computed timing, not a hard-coded 5.2s.\n\nFiles\n- index.html: re-run delay computation after variants apply.\n- styles.css: use var(--progress-delay) for progress sweep start.\n- script.js: add applyDynamicDelays(), integrate with StatCycler.\n\nTesting\n- Load main page with/without variant changes; verify reveal order remains brand → headline → description → bullets → form.\n- Trigger early scroll; AnimationSpeedController still completes everything immediately.\n\nNo visual regressions expected; only timing logic changed.