### PR TITLE
chore: move Cloudflare Web Analytics to head

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -17,6 +17,7 @@
     
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="auth-styles.css">
+    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
     
     <!-- Supabase -->
     <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
@@ -197,6 +198,6 @@
     </div>
 
     <script src="auth.js"></script>
-    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
+    
 </body>
 </html>

--- a/index-ai-orchestration.html
+++ b/index-ai-orchestration.html
@@ -22,6 +22,7 @@
     
     <link rel="stylesheet" href="styles.css">
     <script src="three.min.js"></script>
+    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>
     <!-- Ambient Background -->
@@ -192,7 +193,7 @@
     <script src="script.js"></script>
     <script src="gravitational-singularity.js"></script>
     
-    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
+    
     <!-- Mobile Modal (Tooltip Replacement) -->
     <div class="bottom-sheet" id="bottom-sheet">
         <div class="bottom-sheet-overlay"></div>

--- a/index-developer.html
+++ b/index-developer.html
@@ -22,6 +22,7 @@
     
     <link rel="stylesheet" href="styles.css">
     <script src="three.min.js"></script>
+    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>
     <!-- Ambient Background -->
@@ -190,7 +191,7 @@
     <script src="script.js"></script>
     <script src="gravitational-singularity.js"></script>
     
-    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
+    
     <!-- Mobile Modal (Tooltip Replacement) -->
     <div class="bottom-sheet" id="bottom-sheet">
         <div class="bottom-sheet-overlay"></div>

--- a/index-pattern-computing.html
+++ b/index-pattern-computing.html
@@ -22,6 +22,7 @@
     
     <link rel="stylesheet" href="styles.css">
     <script src="three.min.js"></script>
+    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>
     <!-- Ambient Background -->
@@ -191,7 +192,7 @@
     <script src="script.js"></script>
     <script src="gravitational-singularity.js"></script>
     
-    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
+    
     <!-- Mobile Modal (Tooltip Replacement) -->
     <div class="bottom-sheet" id="bottom-sheet">
         <div class="bottom-sheet-overlay"></div>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     
     <link rel="stylesheet" href="styles.css">
     <script src="three.min.js"></script>
+    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>
     <!-- Ambient Background -->
@@ -351,10 +352,7 @@
     <script src="script.js"></script>
     <script src="gravitational-singularity.js"></script>
     
-    <!-- Cloudflare Web Analytics -->
-    <script defer src='https://static.cloudflareinsights.com/beacon.min.js'
-            data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script>
-    <!-- End Cloudflare Web Analytics -->
+    
     <!-- Mobile Modal (Tooltip Replacement) -->
     <div class="bottom-sheet" id="bottom-sheet">
         <div class="bottom-sheet-overlay"></div>

--- a/privacy.html
+++ b/privacy.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - WorkspaceOS</title>
+    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
     <script>
         // Redirect to main page with privacy hash
         window.location.replace('/#privacy');
@@ -11,6 +12,6 @@
 </head>
 <body>
     <p>Redirecting to privacy policy...</p>
-    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
+    
 </body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - WorkspaceOS</title>
+    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
     <script>
         // Redirect to main page with privacy hash
         window.location.replace('/#privacy');
@@ -11,6 +12,6 @@
 </head>
 <body>
     <p>Redirecting to privacy policy...</p>
-    <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "c71909abc8ce48cd99072246781b8353"}'></script><!-- End Cloudflare Web Analytics -->
+    
 </body>
 </html>


### PR DESCRIPTION
Move the Cloudflare Web Analytics beacon (defer) from the end of body to the head across all pages for earlier, consistent initialization.\n\n- Updated: index.html, index-ai-orchestration.html, index-developer.html, index-pattern-computing.html, auth.html, privacy.html, privacy/index.html\n- Removed duplicate body inclusions\n\nNo functional code changed aside from snippet placement.